### PR TITLE
Update WrapC to generate TYPED_POINTER 

### DIFF
--- a/src/library/ast/c_ast/phase_2/type/ewg_c_ast_primitive_type.e
+++ b/src/library/ast/c_ast/phase_2/type/ewg_c_ast_primitive_type.e
@@ -34,11 +34,12 @@ feature
 			-- TODO: Take care of how different platforms handle C types.
 			if attached name as l_name then
 				if l_name.has_substring ("int") or
-					l_name.has_substring ("long") or
-					l_name.has_substring ("signed") or -- includes 'unsigned'
+					--l_name.has_substring ("signed") or -- includes 'unsigned'
 					l_name.has_substring ("short") or
 					l_name.has_substring ("_Bool") then -- TODO: this should really be mapped to BOOLEAN. Needs changes all over the place probably.
 					Result := "INTEGER"
+				elseif l_name.has_substring ("long") then
+					Result := "INTEGER_64"
 				elseif l_name.has_substring ("char") then
 					Result := "CHARACTER"
 				elseif l_name.has_substring ("double") then
@@ -54,6 +55,14 @@ feature
 					Result := "UNKNOWN"
 					-- TODO: double check what to do with this
 					-- or just return detachable STRING
+				end
+				-- Check for unsigned
+				if l_name.has_substring ("unsigned") then
+					if Result.same_string ("INTEGER_64") then
+						Result := "NATURAL_64"
+					elseif Result.same_string ("INTEGER") then
+						Result := "NATURAL"
+					end
 				end
 			else
 				Result := "UNKNOWN"

--- a/src/library/generator/eiffel_api/ewg_eiffel_api_function_wrapper_generator.e
+++ b/src/library/generator/eiffel_api/ewg_eiffel_api_function_wrapper_generator.e
@@ -422,7 +422,14 @@ feature {NONE} -- Generate Eiffel High Level Access
 			else
 				output_stream.put_string (eiffel_parameter_name_from_c_parameter_name (a_native_member_wrapper.mapped_eiffel_name))
 				output_stream.put_string (": ")
-				output_stream.put_string (a_native_member_wrapper.eiffel_type)
+				if attached {EWG_C_AST_POINTER_TYPE} a_native_member_wrapper.c_declaration.type as l_type and then
+				   attached {EWG_C_AST_PRIMITIVE_TYPE} l_type.base as l_base then
+					output_stream.put_string ("TYPED_POINTER [")
+					output_stream.put_string (l_base.corresponding_eiffel_type)
+					output_stream.put_string ("]")
+				else
+					output_stream.put_string (a_native_member_wrapper.eiffel_type)
+				end
 			end
 		end
 

--- a/testing/generator.bat
+++ b/testing/generator.bat
@@ -1,0 +1,4 @@
+@echo on
+title Script to automate WrapC development process.
+
+wrap_c --verbose --script_pre_process=pre_script.bat --script_post_process=post_script.bat --output-dir=%cd%/generated_wrapper  --full-header=%cd%/manual_wrapper/c/include/wrapc_testing.h  --config=%cd%/config.xml

--- a/testing/generator.sh
+++ b/testing/generator.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+#Script to automate WrapC development process.
+wrap_c --verbose --script_pre_process=pre_script.sh --script_post_process=post_script.sh  --output-dir=./generated_wrapper --full-header=./manual_wrapper/c/include/wrapc_testing.h --config=config.xml
+

--- a/testing/manual_wrapper/c/include/wrapc_testing.h
+++ b/testing/manual_wrapper/c/include/wrapc_testing.h
@@ -1,0 +1,71 @@
+#ifndef WRAPC_TESTING_H
+#define WRAPC_TESTING_H
+#include <stdio.h>
+
+//In C we can implement output paramenters providing an argument that is a pointer.
+
+// return a value of type int the output parameter `count`.
+void getIntValue(int* count );
+
+// return a value of type Unsigned int the output parameter `count`.
+void getUnsignedIntValue(unsigned int* count );
+
+// return a value of type long the output parameter `count`.
+void getLongValue(long* count );
+
+// return a value of type Unsigned int the output parameter `count`.
+void getUnsignedLongValue(unsigned long* count );
+
+// return a value of type float the output parameter `count`.
+void getFloatValue(float* count );
+
+// return a value of type double the output parameter `count`.
+void getDoubleValue(double* count );
+
+#endif
+
+// Implementation
+
+#ifdef WRAPC_TESTING_IMPL
+
+void getIntValue(int* count ){
+ 	
+ 	* count = -10;
+}
+
+void getUnsignedIntValue(unsigned int* count ){
+ 	
+ 	* count = 10;
+}
+
+void getLongValue(long* count ){
+ 	
+
+ 	* count = (long) 2147;
+}
+
+void getUnsignedLongValue(unsigned long* count ){
+ 	
+ 	* count = 10;
+}
+
+
+
+void getFloatValue(float* count ){
+ 	
+ 		
+ 	* count = (float) 10.5;
+}
+
+
+void getDoubleValue(double* count ){
+ 	
+ 	* count = (double) 3.142857;
+}
+
+#endif
+
+
+
+
+

--- a/testing/manual_wrapper/c/include/wrapc_testing.h
+++ b/testing/manual_wrapper/c/include/wrapc_testing.h
@@ -22,6 +22,12 @@ void getFloatValue(float* count );
 // return a value of type double the output parameter `count`.
 void getDoubleValue(double* count );
 
+// return a value of type double the output parameter `count`.
+void getCharValue(char* val );
+
+// return a value of type double the output parameter `count`.
+void getUnsingedCharValue(unsigned char* val );
+
 #endif
 
 // Implementation
@@ -49,8 +55,6 @@ void getUnsignedLongValue(unsigned long* count ){
  	* count = 10;
 }
 
-
-
 void getFloatValue(float* count ){
  	
  		
@@ -61,6 +65,16 @@ void getFloatValue(float* count ){
 void getDoubleValue(double* count ){
  	
  	* count = (double) 3.142857;
+}
+
+void getCharValue(char* val ){
+ 	
+ 	* val = 97;
+}
+
+void getUnsingedCharValue(unsigned char* val ){
+ 	
+ 	* val = 97;
 }
 
 #endif

--- a/testing/post_script.bat
+++ b/testing/post_script.bat
@@ -1,0 +1,29 @@
+@echo off
+title post_process script
+
+rem copy c file is there any
+copy .\manual_wrapper\c\src\*.c  .\generated_wrapper\c\src
+copy .\manual_wrapper\c\include\*.h  .\generated_wrapper\c\include		
+
+rem copy Makefile script
+copy Makefile-win.SH  .\generated_wrapper\c\src
+
+rem deleting unneeded files
+
+cd .\generated_wrapper\eiffel
+
+del /f corecrt_wstdio_functions_api.e
+del /f crt_locale_data_struct_api.e
+del /f crt_multibyte_data_struct_api.e
+del /f iobuf_struct_api.e
+del /f mbstatet_struct_api.e
+del /f stdio_functions_api.e
+del /f crt_locale_pointers_struct_api.e
+
+cd ..
+cd ..
+
+
+rem Compile C glue code.
+cd generated_wrapper/c/src/
+finish_freezing -library

--- a/testing/post_script.sh
+++ b/testing/post_script.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Post processing script
+
+# copy C file is there any
+cp ./manual_wrapper/c/src/*.c  ./generated_wrapper/c/src
+cp ./manual_wrapper/c/include/*.h  ./generated_wrapper/c/include		
+
+#copy Makefile
+cp Makefile.SH  ./generated_wrapper/c/src
+
+
+#Compile C glue code.
+cd generated_wrapper/c/src/
+finish_freezing -library

--- a/testing/pre_compile_action.bat
+++ b/testing/pre_compile_action.bat
@@ -1,0 +1,8 @@
+setlocal
+set CWD=%cd%
+
+%ISE_EIFFEL%\tools\spec\%ISE_PLATFORM%\bin\espawn.exe "%ISE_EIFFEL%\tools\spec\%ISE_PLATFORM%\bin\wrap_c.exe --verbose --script_pre_process=%cd%\pre_script.bat --script_post_process=%cd%\post_script.bat --output-dir=%cd%\generated_wrapper  --full-header=%cd%\manual_wrapper\c\include\wrapc_testing.h  --config=config.xml
+
+cd %CWD%
+
+exit /b 0

--- a/testing/pre_compile_action.sh
+++ b/testing/pre_compile_action.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set CWD=`pwd`
+cd ../../library
+
+$ISE_EIFFEL/tools/spec/$ISE_PLATFORM/bin/wrap_c --verbose --script_pre_process=pre_script.sh --script_post_process=post_script.sh --output-dir=generated_wrapper  --full-header=./manual_wrapper/c/include/callback.h  --config=config.xml
+
+cd $CWD
+
+exit 0

--- a/testing/pre_script.bat
+++ b/testing/pre_script.bat
@@ -1,0 +1,10 @@
+@echo on
+title pre_process script
+echo Removing generated code.
+
+set current_dir = %~dp0
+del /f callback_cpp.h
+rd /s /q generated_wrapper
+cd %current_dir%C/
+rd /s /q spec
+cd ..

--- a/testing/pre_script.sh
+++ b/testing/pre_script.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Pre processing script
+#Delete generated code
+echo Removing generated code.
+rm callback_cpp.h
+rm -r generated_wrapper
+cd C/
+rm -r spec

--- a/testing/typed_pointer_test.e
+++ b/testing/typed_pointer_test.e
@@ -1,0 +1,91 @@
+note
+	description: "[
+		Eiffel tests that can be executed by testing tool.
+	]"
+	author: "EiffelStudio test wizard"
+	date: "$Date$"
+	revision: "$Revision$"
+	testing: "type/manual"
+
+class
+	TYPED_POINTER_TEST
+
+inherit
+	EQA_TEST_SET
+
+feature -- Test routines
+
+	test_typed_pointer_int
+		local
+			i: INTEGER
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_int_value ($i)
+			assert ("Expected i = -10", i = -10)
+		end
+
+	test_typed_pointer_unsinged_int
+		local
+			n: NATURAL
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_unsigned_int_value ($n)
+			assert ("Expected n = 10", n = 10)
+		end
+
+	test_typed_pointer_long
+		local
+			l: INTEGER_64
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_long_value ($l)
+			assert ("Expected l = 2147", l = 2147)
+		end
+
+	test_typed_pointer_unsigned_long
+		local
+			n: NATURAL_64
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_unsigned_long_value ($n)
+			assert ("Expected n = 10", n = 10)
+		end
+
+	test_typed_pointer_float
+		local
+			f: REAL
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_float_value ($f)
+			assert ("Expected f = 10.5", f = 10.5)
+		end
+
+	test_typed_pointer_double
+		local
+			d: REAL_64
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_double_value ($d)
+			assert ("Expected f = 3.142857", d.ieee_is_less_equal({REAL_64} 3.142857))
+		end
+
+	test_typed_pointer_char
+		local
+			c: CHARACTER
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_char_value ($c)
+			assert ("Expected c = a", c = 'a')
+		end
+
+	test_typed_pointer_unsigned_char
+		local
+			c: CHARACTER
+		do
+			{WRAPC_TESTING_FUNCTIONS_API}.get_unsinged_char_value ($c)
+			assert ("Expected c = a", c = 'a')
+		end
+
+feature {NONE} -- Implementation
+
+	c_define
+		external "C inline"
+		alias
+			"#define WRAPC_TESTING_IMPL"
+		end
+end
+
+

--- a/testing/wrapc_testing.ecf
+++ b/testing/wrapc_testing.ecf
@@ -1,72 +1,44 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-16-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-16-0 http://www.eiffel.com/developers/xml/configuration-1-16-0.xsd" name="wrapc_testing" uuid="EC99C77B-E53E-4677-9C75-09C5B3C187E4">
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-21-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-21-0 http://www.eiffel.com/developers/xml/configuration-1-21-0.xsd" name="wrapc_testing" uuid="EC99C77B-E53E-4677-9C75-09C5B3C187E4">
 	<target name="wrapc_testing">
-		<root feature="make" class="APPLICATION"/>
+		<root class="APPLICATION" feature="make"/>
 		<file_rule>
-			<exclude>/\.git$</exclude>
-			<exclude>/\.svn$</exclude>
+			<exclude>/C$</exclude>
 			<exclude>/CVS$</exclude>
 			<exclude>/EIFGENs$</exclude>
-			<exclude>/C$</exclude>
+			<exclude>/\.git$</exclude>
+			<exclude>/\.svn$</exclude>
 		</file_rule>
-		<option warning="true">
+		<option warning="warning" manifest_array_type="mismatch_warning">
 			<assertions precondition="true" postcondition="true" check="true" invariant="true" loop="true" supplier_precondition="true"/>
 		</option>
-
-		<!--
-		<pre_compile_action working_directory=".\" command="/bin/sh ./pre_compile_action.sh" succeed="true">
-			<condition>
-				<platform excluded_value="windows"/>
-			</condition>
-		</pre_compile_action>
-
-		<pre_compile_action working_directory=".\" command="pre_compile_action.bat" succeed="true">
-			<condition>
-				<platform value="windows"/>
-			</condition>
-		</pre_compile_action>
-	    -->
-
 		<external_include location="$ECF_CONFIG_PATH\generated_wrapper\c\include">
 			<condition>
 				<platform value="windows"/>
 			</condition>
 		</external_include>
-		
 		<external_include location="$ECF_CONFIG_PATH\manual_wrapper\c\include">
 			<condition>
 				<platform value="windows"/>
-			</condition>		
+			</condition>
 		</external_include>
-		
 		<external_include location="$ECF_CONFIG_PATH/generated_wrapper/c/include">
 			<condition>
 				<platform excluded_value="windows"/>
 			</condition>
 		</external_include>
-		
-		<external_include location="$ECF_CONFIG_PATH/manual_wrapper/c/include">
-			<condition>
-				<platform excluded_value="windows"/>
-			</condition>		
-		</external_include>
-		
 		<external_object location="$ECF_CONFIG_PATH/C/spec/$ISE_C_COMPILER/$ISE_PLATFORM/lib/eif_wrapc_testing.lib">
 			<condition>
 				<platform value="windows"/>
 			</condition>
 		</external_object>
-
 		<external_object location="$ECF_CONFIG_PATH/C/spec/$(ISE_PLATFORM)/lib/eif_wrapc_testing.a">
 			<condition>
 				<platform excluded_value="windows"/>
 			</condition>
 		</external_object>
-
-
-		<setting name="console_application" value="true"/>
-		<precompile name="base_pre" location="$ISE_PRECOMP/base-scoop-safe.ecf"/>
-		<library name="base" location="$ISE_LIBRARY/library/base/base.ecf"/>
+		<library name="base" location="$ISE_LIBRARY\library\base\base.ecf"/>
+		<library name="testing" location="$ISE_LIBRARY\library\testing\testing.ecf"/>
 		<cluster name="wrapc_testing" location=".\" recursive="true"/>
 	</target>
 </system>

--- a/testing/wrapc_testing.ecf
+++ b/testing/wrapc_testing.ecf
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-16-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-16-0 http://www.eiffel.com/developers/xml/configuration-1-16-0.xsd" name="wrapc_testing" uuid="EC99C77B-E53E-4677-9C75-09C5B3C187E4">
+	<target name="wrapc_testing">
+		<root feature="make" class="APPLICATION"/>
+		<file_rule>
+			<exclude>/\.git$</exclude>
+			<exclude>/\.svn$</exclude>
+			<exclude>/CVS$</exclude>
+			<exclude>/EIFGENs$</exclude>
+			<exclude>/C$</exclude>
+		</file_rule>
+		<option warning="true">
+			<assertions precondition="true" postcondition="true" check="true" invariant="true" loop="true" supplier_precondition="true"/>
+		</option>
+
+		<!--
+		<pre_compile_action working_directory=".\" command="/bin/sh ./pre_compile_action.sh" succeed="true">
+			<condition>
+				<platform excluded_value="windows"/>
+			</condition>
+		</pre_compile_action>
+
+		<pre_compile_action working_directory=".\" command="pre_compile_action.bat" succeed="true">
+			<condition>
+				<platform value="windows"/>
+			</condition>
+		</pre_compile_action>
+	    -->
+
+		<external_include location="$ECF_CONFIG_PATH\generated_wrapper\c\include">
+			<condition>
+				<platform value="windows"/>
+			</condition>
+		</external_include>
+		
+		<external_include location="$ECF_CONFIG_PATH\manual_wrapper\c\include">
+			<condition>
+				<platform value="windows"/>
+			</condition>		
+		</external_include>
+		
+		<external_include location="$ECF_CONFIG_PATH/generated_wrapper/c/include">
+			<condition>
+				<platform excluded_value="windows"/>
+			</condition>
+		</external_include>
+		
+		<external_include location="$ECF_CONFIG_PATH/manual_wrapper/c/include">
+			<condition>
+				<platform excluded_value="windows"/>
+			</condition>		
+		</external_include>
+		
+		<external_object location="$ECF_CONFIG_PATH/C/spec/$ISE_C_COMPILER/$ISE_PLATFORM/lib/eif_wrapc_testing.lib">
+			<condition>
+				<platform value="windows"/>
+			</condition>
+		</external_object>
+
+		<external_object location="$ECF_CONFIG_PATH/C/spec/$(ISE_PLATFORM)/lib/eif_wrapc_testing.a">
+			<condition>
+				<platform excluded_value="windows"/>
+			</condition>
+		</external_object>
+
+
+		<setting name="console_application" value="true"/>
+		<precompile name="base_pre" location="$ISE_PRECOMP/base-scoop-safe.ecf"/>
+		<library name="base" location="$ISE_LIBRARY/library/base/base.ecf"/>
+		<cluster name="wrapc_testing" location=".\" recursive="true"/>
+	</target>
+</system>


### PR DESCRIPTION
Updated code generator to generate `TYPED_POINTER` instead of `POINTER` in signatures of external functions that use addresses of value of basic types. 