### PR TITLE
Updated feature {EWG_C_AST_PRIMITIVE_TYPE}.corresponding_eiffel_type 

### DIFF
--- a/src/library/ast/c_ast/phase_2/type/ewg_c_ast_primitive_type.e
+++ b/src/library/ast/c_ast/phase_2/type/ewg_c_ast_primitive_type.e
@@ -60,7 +60,7 @@ feature
 				if l_name.has_substring ("unsigned") then
 					if Result.same_string ("INTEGER_64") then
 						Result := "NATURAL_64"
-					elseif Result.same_string ("INTEGER") then
+					elseif Result.same_string ("INTEGER") or else Result.same_string ("CHARACTER")then
 						Result := "NATURAL"
 					end
 				end


### PR DESCRIPTION
Mapping C type `unsigned char` or `unsigned int` as `NATURAL` in Eiffel