### PR TITLE
Updated C type mapping to Eiffel.

### DIFF
--- a/bin/Readme.md
+++ b/bin/Readme.md
@@ -1,4 +1,3 @@
  Wrap_C (the package) contains two tools: under bin directory.
 
     WRAP_C -- The Eiffel Wrapper Generator command line tool.
-    escript -- An Eiffel application that helps to post process the generated code.

--- a/src/ewg/wrapc_safe.ecf
+++ b/src/ewg/wrapc_safe.ecf
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system
-	xmlns="http://www.eiffel.com/developers/xml/configuration-1-20-0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-20-0 http://www.eiffel.com/developers/xml/configuration-1-20-0.xsd"
-	name="wrap_c"
-	uuid="2F7D69D7-4063-45FC-B5BD-698E010904AD"
->
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-21-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-21-0 http://www.eiffel.com/developers/xml/configuration-1-21-0.xsd" name="wrap_c" uuid="2F7D69D7-4063-45FC-B5BD-698E010904AD">
 	<target name="wrap_c">
 		<root class="EWG" feature="make"/>
-		<option debug="true" full_class_checking="false" is_attached_by_default="true" manifest_array_type="mismatch_warning" warning="true">
-			<debug name="gelex" enabled="false"/>
-			<debug name="geyacc" enabled="false"/>
-			<assertions check="true" invariant="true" loop="false" postcondition="true" precondition="true" supplier_precondition="true"/>
+		<option debug="false" warning="warning" full_class_checking="false" is_attached_by_default="true" manifest_array_type="mismatch_warning">
+			<debug name="gelex" enabled="true"/>
+			<debug name="geyacc" enabled="true"/>
+			<assertions precondition="true" postcondition="true" check="true" invariant="true" supplier_precondition="true"/>
 		</option>
 		<setting name="console_application" value="true"/>
 		<setting name="inlining_size" value="0"/>
@@ -27,8 +21,8 @@
 		<library name="time" location="${ISE_LIBRARY}\library\time\time.ecf" readonly="true"/>
 		<library name="wrapc_kernel" location="..\library\wrapc_kernel_safe.ecf" readonly="false">
 			<option debug="false">
-				<debug name="gelex" enabled="false"/>
-				<debug name="geyacc" enabled="false"/>
+				<debug name="gelex" enabled="true"/>
+				<debug name="geyacc" enabled="true"/>
 			</option>
 		</library>
 		<cluster name="ewg" location=".\"/>

--- a/src/library/ast/c_ast/phase_2/type/ewg_c_ast_primitive_type.e
+++ b/src/library/ast/c_ast/phase_2/type/ewg_c_ast_primitive_type.e
@@ -46,6 +46,8 @@ feature
 					Result := "REAL_64"
 				elseif l_name.has_substring ("float") then
 					Result := "REAL"
+				elseif l_name.is_case_insensitive_equal ("unsigned") then
+					Result := "NATURAL"  -- unsigned is a short cut for unsigned int.
 				elseif l_name.has_substring ("void") then
 					Result := "WHAT_SHOULD_I_DO_WITH_VOID"
 				else

--- a/utils/testing/application.e
+++ b/utils/testing/application.e
@@ -11,6 +11,13 @@ create
 
 feature -- Initialization
 
+	c_define
+		external "C inline"
+		alias
+			"#define C2EIFFEL_IMPL"
+		end
+
+
 	make
 			-- Run application.
 		do
@@ -84,11 +91,6 @@ feature -- Initialization
 			end
 		end
 
-	c_define
-		external "C inline"
-		alias
-			"#define C2EIFFEL_IMPL"
-		end
 
 note
 	copyright: "Copyright (c) 1984-2019, Eiffel Software and others"


### PR DESCRIPTION
Updating feature corresponding_eiffel_type to map unsigned as a short cut of `unsigned int` to `NATURAL`.