### PR TITLE
Updated C glue code header generator to use `extern`

### DIFF
--- a/src/ewg/wrapc_safe.ecf
+++ b/src/ewg/wrapc_safe.ecf
@@ -1,30 +1,46 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-21-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-21-0 http://www.eiffel.com/developers/xml/configuration-1-21-0.xsd" name="wrap_c" uuid="2F7D69D7-4063-45FC-B5BD-698E010904AD">
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-22-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-22-0 http://www.eiffel.com/developers/xml/configuration-1-22-0.xsd" name="wrap_c" uuid="2F7D69D7-4063-45FC-B5BD-698E010904AD">
 	<target name="wrap_c">
 		<root class="EWG" feature="make"/>
-		<option debug="false" warning="warning" full_class_checking="false" is_attached_by_default="true" manifest_array_type="mismatch_warning">
+		<option debug="false" warning="warning" full_class_checking="false" is_attached_by_default="true" is_obsolete_iteration="true" manifest_array_type="mismatch_warning">
 			<debug name="gelex" enabled="true"/>
 			<debug name="geyacc" enabled="true"/>
-			<assertions precondition="true" postcondition="true" check="true" invariant="true" supplier_precondition="true"/>
+			<assertions postcondition="true" check="true" invariant="true"/>
 		</option>
 		<setting name="console_application" value="true"/>
 		<setting name="inlining_size" value="0"/>
 		<setting name="msil_classes_per_module" value="5"/>
 		<setting name="dead_code_removal" value="feature"/>
 		<capability>
-			<concurrency support="none" use="none"/>
-			<void_safety support="all" use="all"/>
+			<concurrency support="none"/>
+			<void_safety support="all"/>
 		</capability>
-		<library name="base" location="${ISE_LIBRARY}\library\base\base.ecf" readonly="true"/>
-		<library name="kernel" location="$ISE_LIBRARY\contrib\library\gobo\library\kernel\src\library.ecf" readonly="true"/>
-		<library name="regexp" location="$ISE_LIBRARY\contrib\library\gobo\library\regexp\src\library.ecf" readonly="true"/>
-		<library name="time" location="${ISE_LIBRARY}\library\time\time.ecf" readonly="true"/>
+		<library name="base" location="${ISE_LIBRARY}\library\base\base.ecf" readonly="true">
+			<option>
+			</option>
+		</library>
+		<library name="kernel" location="$ISE_LIBRARY\contrib\library\gobo\library\kernel\src\library.ecf" readonly="true">
+			<option>
+			</option>
+		</library>
+		<library name="regexp" location="$ISE_LIBRARY\contrib\library\gobo\library\regexp\src\library.ecf" readonly="true">
+			<option>
+			</option>
+		</library>
+		<library name="time" location="${ISE_LIBRARY}\library\time\time.ecf" readonly="true">
+			<option>
+			</option>
+		</library>
 		<library name="wrapc_kernel" location="..\library\wrapc_kernel_safe.ecf" readonly="false">
 			<option debug="false">
 				<debug name="gelex" enabled="true"/>
 				<debug name="geyacc" enabled="true"/>
+				<assertions postcondition="true" check="true" invariant="true"/>
 			</option>
 		</library>
-		<cluster name="ewg" location=".\"/>
+		<cluster name="ewg" location=".\">
+			<option is_obsolete_iteration="true">
+			</option>
+		</cluster>
 	</target>
 </system>

--- a/src/library/generator/c_glue_code/ewg_c_glue_header_ansi_c_callback_wrapper_generator.e
+++ b/src/library/generator/c_glue_code/ewg_c_glue_header_ansi_c_callback_wrapper_generator.e
@@ -189,6 +189,7 @@ feature {NONE} -- Implementation
 
 	generate_entry_object (a_callback_wrapper: EWG_CALLBACK_WRAPPER)
 		do
+			output_stream.put_string ("extern ")
 			output_stream.put_string ("void* ")
 			output_stream.put_string (a_callback_wrapper.mapped_eiffel_name)
 			output_stream.put_line ("_object;")
@@ -203,6 +204,7 @@ feature {NONE} -- Implementation
 			until
 				i > a_count
 			loop
+				output_stream.put_string ("extern ")
 				output_stream.put_string (a_callback_wrapper.mapped_eiffel_name)
 				output_stream.put_string ("_eiffel_feature ")
 				output_stream.put_string (a_callback_wrapper.mapped_eiffel_name)


### PR DESCRIPTION
keyword explicitly when we declare variables without defining them.
This avoid compilation issues with the latest gcc version >= 10.